### PR TITLE
Add rockets lists render

### DIFF
--- a/src/pages/RocketsCards.js
+++ b/src/pages/RocketsCards.js
@@ -1,10 +1,14 @@
 import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
-import { getRocket } from '../redux/rockets/rockets';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  getRocket,
+} from '../redux/rockets/rockets';
 
 const RocketsCards = () => {
   const dispatch = useDispatch();
   const fetchApi = 'https://api.spacexdata.com/v3/rockets';
+
+  const myRocketArray = useSelector((state) => state.rockets);
 
   useEffect(() => {
     const apiRockets = async () => {
@@ -12,29 +16,29 @@ const RocketsCards = () => {
       const rockets = await fetchRockets.json();
       return dispatch(getRocket(rockets));
     };
-    apiRockets();
+    if (myRocketArray.length === 0) {
+      apiRockets();
+    }
   }, []);
 
   return (
-    <div>
-      <div>
-        <img src="" className="rocket-img" alt="" />
-      </div>
-      <div>
-        <h4>Rocket Name</h4>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis interdum
-          dolor et tortor mattis pellentesque. Aliquam aliquet mollis felis,
-          malesuada commodo nisl congue sit amet. Nullam mauris elit, posuere
-          sed facilisis quis, dictum imperdiet augue
-        </p>
-        <button
-          type="button"
-          title="button"
-        >
-          Reserve
-        </button>
-      </div>
+    <div className="rocket-card">
+      {myRocketArray.map((rocket) => (
+        <div key={rocket.id} className="rockets-div">
+          <div className="rocket-imgs">
+            <img
+              src={rocket.flickr_images}
+              alt={rocket.rocket_name}
+              width="300"
+              height="200"
+              className="rocket-img"
+            />
+          </div>
+          <div className="rockets-desc">
+            <h3 className="rockets-desc-title">{rocket.rocket_name}</h3>
+          </div>
+        </div>
+      ))}
     </div>
   );
 };


### PR DESCRIPTION
This Pull Request is created to achieve the following: 

- Use `useSelector()` Redux Hook to select the state slices and render lists of rockets in corresponding routes. i.e.:
```javascript
// get rockets data from the store
const rockets = useSelector(state => state.rockets);
```

- You can style the whole application "by hand" or you could use [React Bootstrap](https://react-bootstrap.github.io/), a UI library that could speed up the process. This is a popular library and working with its components would be good practice.
- Render a list of rockets (as per design). For the image of a rocket use the first image in the array of `flickr_images`.
