### PR TITLE
Implement badges for missions

### DIFF
--- a/src/pages/MissionList.js
+++ b/src/pages/MissionList.js
@@ -43,6 +43,13 @@ const MissionsList = () => {
             const bdj = badgeClass(mission.joined);
             let memberStatus;
             let memberAction;
+            if (mission.joined) {
+              memberAction = 'Leave mission';
+              memberStatus = 'Active member';
+            } else {
+              memberAction = 'Join mission';
+              memberStatus = 'NOT A MEMBER';
+            }
             return (
               <tr key={mission.mission_id} className="pb-5">
                 <td>{mission.mission_name}</td>


### PR DESCRIPTION
Missions that the user has joined already should show a badge "Active Member" instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).