### PR TITLE
Add switch-badges-rockets

### DIFF
--- a/src/pages/RocketsCards.js
+++ b/src/pages/RocketsCards.js
@@ -23,12 +23,10 @@ const RocketsCards = () => {
     }
   }, []);
 
-  // eslint-disable-next-line no-unused-vars
   const reserveRockets = (e) => {
     dispatch(reserveRocket(e.target.id));
   };
 
-  // eslint-disable-next-line no-unused-vars
   const unReserveRockets = (e) => {
     dispatch(unreserveRocket(e.target.id));
   };
@@ -62,6 +60,27 @@ const RocketsCards = () => {
               ) : null}
               {rocket.description}
             </p>
+            {rocket.reserved ? (
+              <button
+                type="button"
+                title="button"
+                onClick={unReserveRockets}
+                id={rocket.id}
+                className="unreserve-btn rocktbtn"
+              >
+                Cancel Reservation
+              </button>
+            ) : (
+              <button
+                type="button"
+                title="button"
+                className="rockets-desc-btn rocktbtn"
+                onClick={reserveRockets}
+                id={rocket.id}
+              >
+                Reserve Rocket
+              </button>
+            )}
           </div>
         </div>
       ))}


### PR DESCRIPTION
This Pull Request is created to achieve the following: 

Rockets that have already been reserved should show Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)

Use the React conditional rendering syntax:
```javascript
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)

Use the React conditional rendering syntax:
```javascript
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```